### PR TITLE
Remove hard-coded jdk location. Breaks Cloud Build.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,0 @@
-org.gradle.java.home=/usr/lib/jvm/java-21-openjdk-amd64


### PR DESCRIPTION
## Summary

Remove Gradle JDK version location

## Issue Reference

AIMS-1162

## Changes

- Remove Gradle JDK version location

## Checklist

- [x] All existing and any new unit tests pass in your IDE

- [x] The version in `version.txt` has been updated [Help on Semantic Versioning](https://semver.org/)